### PR TITLE
fix[DiveEVM2017]: Part6.md bytes count error

### DIFF
--- a/Topics/Translation/DiveEVM2017/DiveEVM2017-Part6.md
+++ b/Topics/Translation/DiveEVM2017/DiveEVM2017-Part6.md
@@ -75,12 +75,12 @@ pragma solidity ^0.4.18;
 
 contract Logger {
 	function Logger() public {
-		log0(0xc0fefe);
+		log0(0xc0fefefe);
 	}
 }
 ```
 
-生成的汇编可以分为两半。前半部分将日志数据（`0xc0fefe`​）从堆栈复制到内存中。后半部分将 `log0`​ 指令的参数放在堆栈上，告诉它在内存中加载数据的位置。
+生成的汇编可以分为两半。前半部分将日志数据（`0xc0fefefe`​）从堆栈复制到内存中。后半部分将 `log0`​ 指令的参数放在堆栈上，告诉它在内存中加载数据的位置。
 
 带注释的汇编：
 
@@ -89,19 +89,19 @@ memory: { 0x40 => 0x60 }
 
 tag_1:
   // copy data into memory
-  0xc0fefe
-    [0xc0fefe]
+  0xc0fefefe
+    [0xc0fefefe]
   mload(0x40)
-    [0x60 0xc0fefe]
+    [0x60 0xc0fefefe]
   swap1
-    [0xc0fefe 0x60]
+    [0xc0fefefe 0x60]
   dup2
-    [0x60 0xc0fefe 0x60]
+    [0x60 0xc0fefefe 0x60]
   mstore
     [0x60]
     memory: {
       0x40 => 0x60
-      0x60 => 0xc0fefe
+      0x60 => 0xc0fefefe
     }
 
 // calculate data start position and size
@@ -163,7 +163,7 @@ pragma solidity ^0.4.18;
 
 contract Logger {
 	function Logger() public {
-		log2(0xc0fefe, 0xaaaa1111, 0xbbbb2222);
+		log2(0xc0fefefe, 0xaaaa1111, 0xbbbb2222);
 	}
 }
 ```
@@ -177,7 +177,7 @@ tag_1:
   0xaaaa1111
 
 // copy data into memory
-  0xc0fefe
+  0xc0fefefe
   mload(0x40)
   swap1
   dup2
@@ -194,12 +194,12 @@ tag_1:
   log2
 ```
 
-数据还是 `0xc0fefe`​，复制到内存。在执行 `log2`​ 之前，EVM 的状态如下所示：
+数据还是 `0xc0fefefe`​，复制到内存。在执行 `log2`​ 之前，EVM 的状态如下所示：
 
 ```shell
 stack: [0x60 0x20 0xaaaa1111 0xbbbb2222]
 memory: {
-  0x60: 0xc0fefe
+  0x60: 0xc0fefefe
 }
 
 log2


### PR DESCRIPTION
Update DiveEVM2017-Part6.md fix bytes count error

示例参数为 32 bit 需要用 8 位 16 进制编码表示，文档中 32 位数据【0xc0fefe】少了 2 位 16 进制编码