### PR TITLE
In Pi Xiu security chapter, correct code with the newest ERC20 hook.

### DIFF
--- a/S10_Honeypot/Honeypot.sol
+++ b/S10_Honeypot/Honeypot.sol
@@ -3,12 +3,12 @@ pragma solidity ^0.8.4;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
-
+ 
 // 极简貔貅ERC20代币，只能买，不能卖
 contract HoneyPot is ERC20, Ownable {
     address public pair;
     // 构造函数：初始化代币名称和代号
-    constructor() ERC20("HoneyPot", "Pi Xiu") {
+    constructor() ERC20("HoneyPot", "Pi Xiu") Ownable(msg.sender){
         address factory = 0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f; // goerli uniswap v2 factory
         address tokenA = address(this); // 貔貅代币地址
         address tokenB = 0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6; //  goerli WETH
@@ -30,19 +30,18 @@ contract HoneyPot is ERC20, Ownable {
         _mint(to, amount);
     }
 
-    /**
-     * @dev See {ERC20-_beforeTokenTransfer}.
+  /**
+     * @dev See {ERC20-_update}.
      * 貔貅函数：只有合约拥有者可以卖出
-     */
-    function _beforeTokenTransfer(
-        address from,
-        address to,
-        uint256 amount
-    ) internal virtual override {
-        super._beforeTokenTransfer(from, to, amount);
-        // 当转账的目标地址为 LP 合约时，会revert
-        if(to == pair){
-            require(from == owner(), "Can not Transfer");
-        }
-    }
+    */
+    function _update(
+      address from,
+      address to,
+      uint256 amount
+  ) internal virtual override {
+     if(to == pair){
+        require(from == owner(), "Can not Transfer");
+      }
+      super._update(from, to, amount);
+  }
 }


### PR DESCRIPTION
@AmazingAng Pls help review this. Thanks.

As the [issue](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3838) from [openzeppelin-contracts](https://github.com/OpenZeppelin/openzeppelin-contracts) shown, the hook `_beforeTokenTransfer` and `_afterTokenTransfer` in ERC20 have been removed. So update the hook code to the Pi Xiu security chapter.