### PR TITLE
fix: adjusting operator when authorizing token

### DIFF
--- a/31_ERC20/ERC20.sol
+++ b/31_ERC20/ERC20.sol
@@ -34,7 +34,7 @@ contract ERC20 is IERC20 {
 
     // @dev 实现 `approve` 函数, 代币授权逻辑
     function approve(address spender, uint amount) external override returns (bool) {
-        allowance[msg.sender][spender] = amount;
+        allowance[msg.sender][spender] += amount;
         emit Approval(msg.sender, spender, amount);
         return true;
     }


### PR DESCRIPTION
当授权代币给用户时，应该使用`+=`，因为在后续的`transferFrom`方法中，使用的是`-=`