### PR TITLE
docs: remove redundant "`" in 15th Errors for English

### DIFF
--- a/Languages/en/15_Errors_en/readme.md
+++ b/Languages/en/15_Errors_en/readme.md
@@ -69,7 +69,7 @@ function transferOwner2(uint256 tokenId, address newOwner) public {
 The `assert` statement is generally used for debugging purposes, because it does not include error message to inform the user.
 Syntax of `assert`: 
 ```solidity
-`assert(condition);
+assert(condition);
 ```
 If the condition is not met, an error will be thrown.
 


### PR DESCRIPTION
 In 15th Chapter's `Errors` part for English, there is a redundant symbol ` :

![redundant symbol](https://github.com/AmazingAng/WTF-Solidity/assets/20450082/ae3fde9f-4ea7-44d3-833a-cef0cbf4c140)
