### PR TITLE
修改MerkleProof庫中的文字說明

### DIFF
--- a/36_MerkleTree/readme.md
+++ b/36_MerkleTree/readme.md
@@ -114,7 +114,7 @@ library MerkleProof {
 
 3.  `_hashPair()`函数：用`keccak256()`函数计算非根节点对应的两个子节点的哈希（排序后）。
 
-我们将`地址0`，`root`和对应的`proof`输入到`verify()`函数，将返回`true`。因为`地址0`在根为`root`的`Merkle Tree`中，且`proof`正确。如果改变了其中任意一个值，都将返回`false`。
+我们将`地址0`的`Hash`，`root`和对应的`proof`输入到`verify()`函数，将返回`true`。因为`地址0`的`Hash`在根为`root`的`Merkle Tree`中，且`proof`正确。如果改变了其中任意一个值，都将返回`false`。
 
 ## 利用`Merkle Tree`发放`NFT`白名单
 


### PR DESCRIPTION
使用MerkleProof庫來驗證時，輸入的變數是地址0的Hash，是因為上述文章使用了hashLeaves這個選項。

### What type of PR is this (这是什么类型的PR)

- [x] Typo(勘误)
- [ ] BUG(程序错误)
- [ ] Improvement(提升)
- [ ] Feature(新特性)

### Which issue(s) this PR fixes(Optional) (这个PR 修复了什么问题 (可选择))

* resolve(修复) : 更正文章內描述

### What this PR does / why we need it (这个PR 做了什么/ 我们为什么需要这个PR)
