### PR TITLE
Chainlink VRF V2 升级至 VRF V2.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ artifacts
 **node_modules**
 **cache**
 **artifacts**
+.deps

--- a/39_Random/Random.sol
+++ b/39_Random/Random.sol
@@ -2,10 +2,10 @@
 pragma solidity ^0.8.21;
 
 import "https://github.com/AmazingAng/WTF-Solidity/blob/main/34_ERC721/ERC721.sol";
-import "@chainlink/contracts/src/v0.8/interfaces/VRFCoordinatorV2Interface.sol";
-import "@chainlink/contracts/src/v0.8/VRFConsumerBaseV2.sol";
+import {VRFConsumerBaseV2Plus} from "@chainlink/contracts/src/v0.8/vrf/dev/VRFConsumerBaseV2Plus.sol";
+import {VRFV2PlusClient} from "@chainlink/contracts/src/v0.8/vrf/dev/libraries/VRFV2PlusClient.sol";
 
-contract Random is ERC721, VRFConsumerBaseV2{
+contract Random is ERC721, VRFConsumerBaseV2Plus{
     // NFT相关
     uint256 public totalSupply = 100; // 总供给
     uint256[100] public ids; // 用于计算可供mint的tokenId
@@ -13,35 +13,33 @@ contract Random is ERC721, VRFConsumerBaseV2{
 
     // chainlink VRF参数
     
-    //VRFCoordinatorV2Interface
-    VRFCoordinatorV2Interface COORDINATOR;
     
     /**
-     * 使用chainlink VRF，构造函数需要继承 VRFConsumerBaseV2
+     * 使用chainlink VRF，构造函数需要继承 VRFConsumerBaseV2Plus
      * 不同链参数填的不一样
      * 网络: Sepolia测试网
-     * Chainlink VRF Coordinator 地址: 0x8103B0A8A00be2DDC778e6e7eaa21791Cd364625
-     * LINK 代币地址: 0x01BE23585060835E02B77ef475b0Cc51aA1e0709
-     * 30 gwei Key Hash: 0x474e34a077df58807dbe9c96d3c009b23b3c6d0cce433e59bbf5b34f823bc56c
+     * Chainlink VRF Coordinator 地址: 0x9ddfaca8183c41ad55329bdeed9f6a8d53168b1b
+     * LINK 代币地址: 0x779877a7b0d9e8603169ddbd7836e478b4624789
+     * 30 gwei Key Hash: 0x787d74caea10b2b357790d5b5247c2f63d1d91572a9846f780606e4d953677ae
      * Minimum Confirmations 最小确认块数 : 3 （数字大安全性高，一般填12）
      * callbackGasLimit gas限制 : 最大 2,500,000
      * Maximum Random Values 一次可以得到的随机数个数 : 最大 500          
      */
-    address vrfCoordinator = 0x8103B0A8A00be2DDC778e6e7eaa21791Cd364625;
-    bytes32 keyHash = 0x474e34a077df58807dbe9c96d3c009b23b3c6d0cce433e59bbf5b34f823bc56c;
+    address vrfCoordinator = 0x9DdfaCa8183c41ad55329BdeeD9F6A8d53168B1B;
+    bytes32 keyHash = 0x787d74caea10b2b357790d5b5247c2f63d1d91572a9846f780606e4d953677ae;
     uint16 requestConfirmations = 3;
     uint32 callbackGasLimit = 1_000_000;
     uint32 numWords = 1;
-    uint64 subId;
+    //订阅ID类型已从VRF V2中的uint64变为VRF V2.5中的uint256
+    uint256 subId;
     uint256 public requestId;
     
     // 记录VRF申请标识对应的mint地址
     mapping(uint256 => address) public requestToSender;
 
-    constructor(uint64 s_subId) 
-        VRFConsumerBaseV2(vrfCoordinator)
+    constructor(uint256 s_subId) 
+        VRFConsumerBaseV2Plus(vrfCoordinator)
         ERC721("WTF Random", "WTF"){
-            COORDINATOR = VRFCoordinatorV2Interface(vrfCoordinator);
             subId = s_subId;
     }
 
@@ -87,12 +85,20 @@ contract Random is ERC721, VRFConsumerBaseV2{
      */
     function mintRandomVRF() public {
         // 调用requestRandomness获取随机数
-        requestId = COORDINATOR.requestRandomWords(
-            keyHash,
-            subId,
-            requestConfirmations,
-            callbackGasLimit,
-            numWords
+        requestId = s_vrfCoordinator.requestRandomWords(
+            VRFV2PlusClient.RandomWordsRequest(
+                {
+                    keyHash:keyHash,
+                    subId:subId,
+                    requestConfirmations: requestConfirmations,
+                    callbackGasLimit: callbackGasLimit,
+                    numWords: numWords,
+                    extraArgs: VRFV2PlusClient._argsToBytes(
+                    //此为是否指定原生代币如ETH等，来支付VRF请求的费用，当为false表示使用LINK代币支付
+                    VRFV2PlusClient.ExtraArgsV1({nativePayment: false})
+                    )
+                }
+            )
         );
         requestToSender[requestId] = msg.sender;
     }
@@ -101,8 +107,8 @@ contract Random is ERC721, VRFConsumerBaseV2{
      * VRF的回调函数，由VRF Coordinator调用
      * 消耗随机数的逻辑写在本函数中
      */
-    function fulfillRandomWords(uint256 requestId, uint256[] memory s_randomWords) internal override{
-        address sender = requestToSender[requestId]; // 从requestToSender中获取minter用户地址
+    function fulfillRandomWords(uint256 _requestId, uint256[] calldata s_randomWords) internal override{
+        address sender = requestToSender[_requestId]; // 从requestToSender中获取minter用户地址
         uint256 tokenId = pickRandomUniqueId(s_randomWords[0]); // 利用VRF返回的随机数生成tokenId
         _mint(sender, tokenId);
     }

--- a/39_Random/RandomNumberConsumer.sol
+++ b/39_Random/RandomNumberConsumer.sol
@@ -1,41 +1,37 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.21;
 
-import "@chainlink/contracts/src/v0.8/interfaces/VRFCoordinatorV2Interface.sol";
-import "@chainlink/contracts/src/v0.8/VRFConsumerBaseV2.sol";
+import {VRFConsumerBaseV2Plus} from "@chainlink/contracts/src/v0.8/vrf/dev/VRFConsumerBaseV2Plus.sol";
+import {VRFV2PlusClient} from "@chainlink/contracts/src/v0.8/vrf/dev/libraries/VRFV2PlusClient.sol";
 
-contract RandomNumberConsumer is VRFConsumerBaseV2{
-
-    //请求随机数需要调用VRFCoordinatorV2Interface接口
-    VRFCoordinatorV2Interface COORDINATOR;
+contract RandomNumberConsumer is VRFConsumerBaseV2Plus{
     
     // 申请后的subId
-    uint64 subId;
+    //订阅ID类型已从VRF V2中的uint64变为VRF V2.5中的uint256
+    uint256 subId;
 
     //存放得到的 requestId 和 随机数
     uint256 public requestId;
     uint256[] public randomWords;
     
     /**
-     * 使用chainlink VRF，构造函数需要继承 VRFConsumerBaseV2
+     * 使用chainlink VRF，构造函数需要继承 VRFConsumerBaseV2Plus
      * 不同链参数填的不一样
-     * 具体可以看：https://docs.chain.link/vrf/v2/subscription/supported-networks
      * 网络: Sepolia测试网
-     * Chainlink VRF Coordinator 地址: 0x8103B0A8A00be2DDC778e6e7eaa21791Cd364625
-     * LINK 代币地址: 0x01BE23585060835E02B77ef475b0Cc51aA1e0709
-     * 30 gwei Key Hash: 0x474e34a077df58807dbe9c96d3c009b23b3c6d0cce433e59bbf5b34f823bc56c
+     * Chainlink VRF Coordinator 地址: 0x9ddfaca8183c41ad55329bdeed9f6a8d53168b1b
+     * LINK 代币地址: 0x779877a7b0d9e8603169ddbd7836e478b4624789
+     * 30 gwei Key Hash: 0x787d74caea10b2b357790d5b5247c2f63d1d91572a9846f780606e4d953677ae
      * Minimum Confirmations 最小确认块数 : 3 （数字大安全性高，一般填12）
      * callbackGasLimit gas限制 : 最大 2,500,000
      * Maximum Random Values 一次可以得到的随机数个数 : 最大 500          
      */
-    address vrfCoordinator = 0x8103B0A8A00be2DDC778e6e7eaa21791Cd364625;
-    bytes32 keyHash = 0x474e34a077df58807dbe9c96d3c009b23b3c6d0cce433e59bbf5b34f823bc56c;
+    address vrfCoordinator = 0x9DdfaCa8183c41ad55329BdeeD9F6A8d53168B1B;
+    bytes32 keyHash = 0x787d74caea10b2b357790d5b5247c2f63d1d91572a9846f780606e4d953677ae;
     uint16 requestConfirmations = 3;
     uint32 callbackGasLimit = 200_000;
     uint32 numWords = 3;
     
-    constructor(uint64 s_subId) VRFConsumerBaseV2(vrfCoordinator){
-        COORDINATOR = VRFCoordinatorV2Interface(vrfCoordinator);
+    constructor(uint256 s_subId) VRFConsumerBaseV2Plus(vrfCoordinator){
         subId = s_subId;
     }
 
@@ -43,12 +39,20 @@ contract RandomNumberConsumer is VRFConsumerBaseV2{
      * 向VRF合约申请随机数 
      */
     function requestRandomWords() external {
-        requestId = COORDINATOR.requestRandomWords(
-            keyHash,
-            subId,
-            requestConfirmations,
-            callbackGasLimit,
-            numWords
+        requestId = s_vrfCoordinator.requestRandomWords(
+            VRFV2PlusClient.RandomWordsRequest(
+                {
+                    keyHash:keyHash,
+                    subId:subId,
+                    requestConfirmations: requestConfirmations,
+                    callbackGasLimit: callbackGasLimit,
+                    numWords: numWords,
+                    extraArgs: VRFV2PlusClient._argsToBytes(
+                    //此为是否指定原生代币如ETH等，来支付VRF请求的费用，当为false表示使用LINK代币支付
+                    VRFV2PlusClient.ExtraArgsV1({nativePayment: false})
+                    )
+                }
+            )
         );
     }
 
@@ -56,7 +60,7 @@ contract RandomNumberConsumer is VRFConsumerBaseV2{
      * VRF合约的回调函数，验证随机数有效之后会自动被调用
      * 消耗随机数的逻辑写在这里
      */
-    function fulfillRandomWords(uint256 requestId, uint256[] memory s_randomWords) internal override {
+    function fulfillRandomWords(uint256 _requestId, uint256[] calldata s_randomWords) internal override {
         randomWords = s_randomWords;
     }
 


### PR DESCRIPTION
### What type of PR is this (这是什么类型的PR)

- [ ] Typo(勘误)
- [ ] BUG(程序错误)
- [x] Improvement(提升)
- [ ] Feature(新特性)

### Which issue(s) this PR fixes(Optional) (这个PR 修复了什么问题 (可选择))
* resolve(修复) : # 针对第39章节内容  Chainlink VRF V2 升级至 VRF V2.5

### What this PR does / why we need it (这个PR 做了什么/ 我们为什么需要这个PR)
当前Chainlink官网不支持VRF V2，获取的subId从uint64变为了uint256，需要进行迁移