### PR TITLE
fix: typo in 20_SendETH_en/readme.md

### DIFF
--- a/Languages/en/20_SendETH_en/readme.md
+++ b/Languages/en/20_SendETH_en/readme.md
@@ -82,7 +82,7 @@ In the `ReceiveETH` contract, when we call `getBalance()`, we can see the balanc
 
 - Usage: `receiverAddress.send(value in Wei)`. 
 - The `gas` limit of `send()` is `2300`, which is enough to make the transfer, but not if the receiving contract has a gas-consuming `fallback()` or `receive()`. 
-- If `send()` fails, the transaction will be `reverted`. 
+- If `send()` fails, the transaction will not be `reverted`. 
 - The return value of `send()` is `bool`, which is the status of the transaction, you can choose to act on that. 
 
 Sample Code:


### PR DESCRIPTION
If `send()` fails, the transaction will **not** be reverted.

### What type of PR is this (这是什么类型的PR)

- [x] Typo(勘误)
- [ ] BUG(程序错误)
- [ ] Improvement(提升)
- [ ] Feature(新特性)

### Which issue(s) this PR fixes(Optional) (这个PR 修复了什么问题 (可选择))

* resolve(修复) : #813 

### What this PR does / why we need it (这个PR 做了什么/ 我们为什么需要这个PR)
1. fix: If `send()` fails, the transaction will **not** be reverted.