### PR TITLE
Enhance readme with gas consumption details

### DIFF
--- a/15_Errors/readme.md
+++ b/15_Errors/readme.md
@@ -103,7 +103,9 @@ function transferOwner3(uint256 tokenId, address newOwner) public {
 2. **`require`方法`gas`消耗**：24755
 3. **`assert`方法`gas`消耗**：24473
 
-我们可以看到，`error`方法`gas`最少，其次是`assert`，`require`方法消耗`gas`最多！因此，`error`既可以告知用户抛出异常的原因，又能省`gas`，大家要多用！（注意，由于部署测试时间的不同，每个函数的`gas`消耗会有所不同，但是比较结果会是一致的。）
+我们可以看到，当`require`带有字符串message时，`error`方法`gas`最少，其次是`assert`，`require`方法消耗`gas`最多！因此，`error`既可以告知用户抛出异常的原因，又能省`gas`，大家要多用！（注意，由于部署测试时间的不同，每个函数的`gas`消耗会有所不同，但是比较结果会是一致的。）
+
+**补充说明：**  若 `require` 不带message（如 require(condition)），其`gas`消耗反而低于 `assert`，因为不带message的`revert`返回空数据，而 `assert` 会返回固定36字节的 Panic(uint256) 错误数据。但此时两者都无法告知用户异常原因，实际开发中仍推荐使用 `error`。
 
 **备注:** Solidity 0.8.0之前的版本，`assert`抛出的是一个 `panic exception`，会把剩余的 `gas` 全部消耗，不会返还。更多细节见[官方文档](https://docs.soliditylang.org/en/v0.8.17/control-structures.html)。
 


### PR DESCRIPTION
Added explanation about gas consumption differences between `require` and `assert`, including the impact of revert message strings.

### What type of PR is this (这是什么类型的PR)

- [ ] Typo(勘误)
- [ ] BUG(程序错误)
- [x] Improvement(提升)
- [ ] Feature(新特性)

### Which issue(s) this PR fixes(Optional) (这个PR 修复了什么问题 (可选择))

None

### What this PR does / why we need it (这个PR 做了什么/ 我们为什么需要这个PR)

本 PR 对 `require` 与 `assert` 的 gas 消耗描述进行了补充说明。

原文中的测试结论基于 `require(condition, "message")` 的情况，但未明确说明这一前提，容易让读者误以为 `require` 在任何情况下都比 `assert` 消耗更多 gas。

本 PR 做了以下补充：

1. 明确原文 gas 对比基于带字符串 message 的 `require`。

2. 补充 `require(condition)` 无 message 的情况，此时其 gas 消耗可能低于 `assert`。

3. 保留原有核心结论，即实际开发中依然更推荐使用自定义 `error`。

这样可以帮助读者更准确地理解 Solidity 中不同错误处理方式的 gas 差异与适用场景，避免产生误解。