### PR TITLE
docs: align storage reference comments in translations

### DIFF
--- a/Languages/es/06_ArreglosyEstructuras_es/ArrayAndStruct.sol
+++ b/Languages/es/06_ArreglosyEstructuras_es/ArrayAndStruct.sol
@@ -45,7 +45,7 @@ contract StructTypes {
     // Asignar el valor a una struct
     // Método 1: Se crea una referencia storage struct en la función
     function initStudent1() external{
-        Student storage _student = student; // Asignar una copia de estudiante
+        Student storage _student = student; // Asignar una referencia al estudiante
         _student.id = 11;
         _student.score = 100;
     }

--- a/Languages/es/06_ArreglosyEstructuras_es/readme.md
+++ b/Languages/es/06_ArreglosyEstructuras_es/readme.md
@@ -97,7 +97,7 @@ Hay 4 maneras de asignar valores a un `struct`:
     // Asignar el valor a una struct
     // Método 1: Se crea una referencia storage struct en la función
     function initStudent1() external{
-        Student storage _student = student; // Asigna una copia de student
+        Student storage _student = student; // Asigna una referencia a student
         _student.id = 11;
         _student.score = 100;
     }

--- a/Languages/pt-br/06_ArrayAndStruct/ArrayAndStruct.sol
+++ b/Languages/pt-br/06_ArrayAndStruct/ArrayAndStruct.sol
@@ -43,7 +43,7 @@ contract StructTypes {
     // Atribuindo valores a uma estrutura
     // Método 1: Criar uma referência struct para storage dentro da função
     function initStudent1() external{
-        // atribuir uma cópia do estudante
+        Student storage _student = student; // atribuir uma referência à struct student
         _student.id = 11;
         _student.score = 100;
     }

--- a/Languages/pt-br/06_ArrayAndStruct/ArrayAndStruct.sol
+++ b/Languages/pt-br/06_ArrayAndStruct/ArrayAndStruct.sol
@@ -39,6 +39,7 @@ contract StructTypes {
         uint256 id;
         uint256 score; 
     }
+    Student student; // Inicializar uma struct Student
     // Inicialize uma estrutura de dados chamada "student"
     // Atribuindo valores a uma estrutura
     // Método 1: Criar uma referência struct para storage dentro da função

--- a/Languages/pt-br/06_ArrayAndStruct/readme.md
+++ b/Languages/pt-br/06_ArrayAndStruct/readme.md
@@ -107,7 +107,7 @@ Há quatro maneiras de atribuir valores a uma struct:
 // Atribuir valores a uma struct
 // Método 1: Criar uma referência struct storage dentro da função
 function initStudent1() external {
-    Student storage _student = student; // atribuir uma cópia da struct student
+    Student storage _student = student; // atribuir uma referência à struct student
     _student.id = 11;
     _student.score = 100;
 }


### PR DESCRIPTION
## Summary

This applies the storage-reference wording fix from #900 to the Spanish and Brazilian Portuguese translations of `06_ArrayAndStruct`.

`Student storage _student = student` creates a storage reference, not a copy. The existing Spanish and pt-br examples still described it as a copy, which can mislead readers about Solidity storage semantics.

## Changes

- Update the Spanish `.sol` and README snippets to say reference instead of copy.
- Update the Brazilian Portuguese README snippet to say reference instead of copy.
- Restore the missing `_student` storage reference declaration in the Brazilian Portuguese `.sol` snippet before it is used.

## Validation

- Verified the translated snippets no longer contain the old copy wording.
- Verified the pt-br Solidity sample declares `_student` before assigning fields.
- Ran `git diff --check`.

Related: #898, #900
