### PR TITLE
docs(flashloan): replace expired public RPC examples

### DIFF
--- a/57_Flashloan/readme.md
+++ b/57_Flashloan/readme.md
@@ -183,10 +183,10 @@ contract UniswapV2FlashloanTest is Test {
 }
 ```
 
-在测试合约中，我们分别测试了手续费充足和不足的情况，你可以在安装Foundry后使用下面的命令行进行测试（你可以将RPC换成其他以太坊RPC）：
+在测试合约中，我们分别测试了手续费充足和不足的情况。请将`FORK_URL`替换为你自己的以太坊主网 RPC URL，不要依赖固定的公共节点：
 
 ```shell
-FORK_URL=https://singapore.rpc.blxrbdn.com
+FORK_URL="https://your-ethereum-mainnet-rpc"
 forge test  --fork-url $FORK_URL --match-path test/UniswapV2Flashloan.t.sol -vv
 ```
 
@@ -352,10 +352,10 @@ contract UniswapV2FlashloanTest is Test {
 }
 ```
 
-在测试合约中，我们分别测试了手续费充足和不足的情况，你可以在安装Foundry后使用下面的命令行进行测试（你可以将RPC换成其他以太坊RPC）：
+在测试合约中，我们分别测试了手续费充足和不足的情况。请将`FORK_URL`替换为你自己的以太坊主网 RPC URL，不要依赖固定的公共节点：
 
 ```shell
-FORK_URL=https://singapore.rpc.blxrbdn.com
+FORK_URL="https://your-ethereum-mainnet-rpc"
 forge test  --fork-url $FORK_URL --match-path test/UniswapV3Flashloan.t.sol -vv
 ```
 
@@ -482,10 +482,10 @@ contract UniswapV2FlashloanTest is Test {
 }
 ```
 
-在测试合约中，我们分别测试了手续费充足和不足的情况，你可以在安装Foundry后使用下面的命令行进行测试（你可以将RPC换成其他以太坊RPC）：
+在测试合约中，我们分别测试了手续费充足和不足的情况。请将`FORK_URL`替换为你自己的以太坊主网 RPC URL，不要依赖固定的公共节点：
 
 ```shell
-FORK_URL=https://singapore.rpc.blxrbdn.com
+FORK_URL="https://your-ethereum-mainnet-rpc"
 forge test  --fork-url $FORK_URL --match-path test/AaveV3Flashloan.t.sol -vv
 ```
 

--- a/Languages/en/57_Flashloan/readme.md
+++ b/Languages/en/57_Flashloan/readme.md
@@ -184,8 +184,10 @@ function testFlashloan() public {
 
 In the test contract, we tested the cases of sufficient and insufficient handling fees respectively. You can use the following command line to test after installing Foundry (you can change the RPC to another Ethereum RPC):
 
+Set `FORK_URL` to your own Ethereum mainnet RPC URL instead of relying on a fixed public endpoint.
+
 ```shell
-FORK_URL=https://singapore.rpc.blxrbdn.com
+FORK_URL="https://your-ethereum-mainnet-rpc"
 forge test  --fork-url $FORK_URL --match-path test/UniswapV2Flashloan.t.sol -vv
 ```
 
@@ -353,8 +355,10 @@ function testFlashloan() public {
 
 In the test contract, we tested the cases of sufficient and insufficient handling fees respectively. You can use the following command line to test after installing Foundry (you can change the RPC to other Ethereum RPC):
 
+Set `FORK_URL` to your own Ethereum mainnet RPC URL instead of relying on a fixed public endpoint.
+
 ```shell
-FORK_URL=https://singapore.rpc.blxrbdn.com
+FORK_URL="https://your-ethereum-mainnet-rpc"
 forge test  --fork-url $FORK_URL --match-path test/UniswapV3Flashloan.t.sol -vv
 ```
 
@@ -483,8 +487,10 @@ function testFlashloan() public {
 
 In the test contract, we tested the cases of sufficient and insufficient handling fees respectively. You can use the following command line to test after installing Foundry (you can change the RPC to another Ethereum RPC):
 
+Set `FORK_URL` to your own Ethereum mainnet RPC URL instead of relying on a fixed public endpoint.
+
 ```shell
-FORK_URL=https://singapore.rpc.blxrbdn.com
+FORK_URL="https://your-ethereum-mainnet-rpc"
 forge test  --fork-url $FORK_URL --match-path test/AaveV3Flashloan.t.sol -vv
 ```
 

--- a/Languages/pt-br/57_Flashloan/readme.md
+++ b/Languages/pt-br/57_Flashloan/readme.md
@@ -171,8 +171,10 @@ contract UniswapV2FlashloanTest is Test {
 
 No contrato de teste, testamos cenários em que a taxa é suficiente e insuficiente. Você pode executar os testes com o Foundry utilizando o seguinte comando (pode trocar o RPC por outro fornecido pela Ethereum):
 
+Defina `FORK_URL` como a URL do seu próprio RPC da mainnet Ethereum; não dependa de um endpoint público fixo.
+
 ```shell
-FORK_URL=https://singapore.rpc.blxrbdn.com
+FORK_URL="https://your-ethereum-mainnet-rpc"
 forge test  --fork-url $FORK_URL --match-path test/UniswapV2Flashloan.t.sol -vv
 ```
 
@@ -336,8 +338,10 @@ function testFlashloan() public {
 
 No contrato de teste, testamos os casos de taxas de manuseio suficientes e insuficientes, respectivamente. Você pode usar a linha de comando a seguir para testar depois de instalar o Foundry (você pode alterar o RPC para outro RPC Ethereum):
 
+Defina `FORK_URL` como a URL do seu próprio RPC da mainnet Ethereum; não dependa de um endpoint público fixo.
+
 ```shell
-FORK_URL=https://singapore.rpc.blxrbdn.com
+FORK_URL="https://your-ethereum-mainnet-rpc"
 forge test  --fork-url $FORK_URL --match-path test/UniswapV3Flashloan.t.sol -vv
 ```
 
@@ -466,8 +470,10 @@ function testFlashloan() public {
 
 No contrato de teste, testamos os casos de taxas de manuseio suficientes e insuficientes, respectivamente. Você pode usar a linha de comando a seguir para testar depois de instalar o Foundry (você pode alterar o RPC para outro RPC Ethereum):
 
+Defina `FORK_URL` como a URL do seu próprio RPC da mainnet Ethereum; não dependa de um endpoint público fixo.
+
 ```shell
-FORK_URL=https://singapore.rpc.blxrbdn.com
+FORK_URL="https://your-ethereum-mainnet-rpc"
 forge test  --fork-url $FORK_URL --match-path test/AaveV3Flashloan.t.sol -vv
 ```
 


### PR DESCRIPTION
### What type of PR is this (这是什么类型的PR)

- [ ] Typo(勘误)
- [x] BUG(程序错误)
- [ ] Improvement(提升)
- [ ] Feature(新特性)

### Which issue(s) this PR fixes(Optional) (这个PR 修复了什么问题 (可选择))

* resolve: #909

### What this PR does / Why we need it (这个PR 做了什么/ 我们为什么需要这个PR)

Replaces the expired fixed public RPC endpoint in the Chinese, English, and Brazilian Portuguese Flashloan lessons with a configurable `FORK_URL` placeholder.

Readers now set their own Ethereum mainnet RPC URL instead of depending on one public endpoint, so the fork-test commands remain usable when a shared endpoint expires or becomes unavailable.
