### PR TITLE
docs(27_ABIEncode): add abi.encodeCall tutorial and example

### DIFF
--- a/27_ABIEncode/ABIEncode.sol
+++ b/27_ABIEncode/ABIEncode.sol
@@ -22,6 +22,13 @@ contract ABIEncode{
     function encodeWithSelector() public view returns(bytes memory result) {
         result = abi.encodeWithSelector(bytes4(keccak256("foo(uint256,address,string,uint256[2])")), x, addr, name, array);
     }
+
+    function foo(uint256, address, string memory, uint256[2] memory) external pure {}
+
+    function encodeCall() public view returns(bytes memory result) {
+        result = abi.encodeCall(this.foo, (x, addr, name, array));
+    }
+
     function decode(bytes memory data) public pure returns(uint dx, address daddr, string memory dname, uint[2] memory darray) {
         (dx, daddr, dname, darray) = abi.decode(data, (uint, address, string, uint[2]));
     }

--- a/27_ABIEncode/readme.md
+++ b/27_ABIEncode/readme.md
@@ -22,7 +22,7 @@ tags:
 
 `ABI` (Application Binary Interface，应用二进制接口)是与以太坊智能合约交互的标准。数据基于他们的类型编码；并且由于编码后不包含类型信息，解码时需要注明它们的类型。
 
-`Solidity`中，`ABI编码`有4个函数：`abi.encode`, `abi.encodePacked`, `abi.encodeWithSignature`, `abi.encodeWithSelector`。而`ABI解码`有1个函数：`abi.decode`，用于解码`abi.encode`的数据。这一讲，我们将学习如何使用这些函数。
+`Solidity`中，`ABI编码`有5个函数：`abi.encode`, `abi.encodePacked`, `abi.encodeWithSignature`, `abi.encodeWithSelector`, `abi.encodeCall`。而`ABI解码`有1个函数：`abi.decode`，用于解码`abi.encode`的数据。这一讲，我们将学习如何使用这些函数。
 
 ## ABI编码
 
@@ -95,6 +95,20 @@ function encodeWithSelector() public view returns(bytes memory result) {
 ```
 
 编码的结果为`0xe87082f1000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000007a58c0be72be218b41c608b7fe7c5bb630736c7100000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000005000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000043078414100000000000000000000000000000000000000000000000000000000`，与`abi.encodeWithSignature`结果一样。
+
+### `abi.encodeCall`
+
+`abi.encodeCall`的第一个参数是函数指针，第二个参数是元组形式的函数参数。与手写字符串签名或函数选择器相比，它会在编译期检查函数签名和参数类型，因此在已知目标函数时更安全。
+
+```solidity
+function foo(uint256, address, string memory, uint256[2] memory) external pure {}
+
+function encodeCall() public view returns(bytes memory result) {
+    result = abi.encodeCall(this.foo, (x, addr, name, array));
+}
+```
+
+它编码出的调用数据与`abi.encodeWithSignature("foo(uint256,address,string,uint256[2])", ...)`相同，但不需要手动拼写函数签名。
 
 ## ABI解码
 

--- a/Languages/pt-br/27_ABIEncode/ABIEncode.sol
+++ b/Languages/pt-br/27_ABIEncode/ABIEncode.sol
@@ -22,6 +22,13 @@ contract ABIEncode{
     function encodeWithSelector() public view returns(bytes memory result) {
         result = abi.encodeWithSelector(bytes4(keccak256("foo(uint256,address,string,uint256[2])")), x, addr, name, array);
     }
+
+    function foo(uint256, address, string memory, uint256[2] memory) external pure {}
+
+    function encodeCall() public view returns(bytes memory result) {
+        result = abi.encodeCall(this.foo, (x, addr, name, array));
+    }
+
     function decode(bytes memory data) public pure returns(uint dx, address daddr, string memory dname, uint[2] memory darray) {
         (dx, daddr, dname, darray) = abi.decode(data, (uint, address, string, uint[2]));
     }

--- a/Languages/pt-br/27_ABIEncode/readme.md
+++ b/Languages/pt-br/27_ABIEncode/readme.md
@@ -22,7 +22,7 @@ Todo o código e tutoriais são de código aberto no GitHub: [github.com/Amazing
 
 `ABI` (Interface Binária de Aplicação) é o padrão para interagir com contratos inteligentes no Ethereum. Os dados são codificados com base em seus tipos; e como a codificação não inclui informações de tipo, a decodificação precisa especificar seus tipos.
 
-Em `Solidity`, a `codificação ABI` possui 4 funções: `abi.encode`, `abi.encodePacked`, `abi.encodeWithSignature`, `abi.encodeWithSelector`. E a `decodificação ABI` tem 1 função: `abi.decode`, usada para decodificar dados codificados por `abi.encode`. Nesta lição, aprenderemos como usar essas funções.
+Em `Solidity`, a `codificação ABI` possui 5 funções: `abi.encode`, `abi.encodePacked`, `abi.encodeWithSignature`, `abi.encodeWithSelector`, `abi.encodeCall`. E a `decodificação ABI` tem 1 função: `abi.decode`, usada para decodificar dados codificados por `abi.encode`. Nesta lição, aprenderemos como usar essas funções.
 
 ## Codificação ABI
 
@@ -82,6 +82,20 @@ function encodeWithSelector() public view returns(bytes memory result) {
 ```
 
 O resultado da codificação é `0xe87082f1000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000007a58c0be72be218b41c608b7fe7c5bb630736c7100000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000005000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000043078414100000000000000000000000000000000000000000000000000000000`, igual ao resultado de `abi.encodeWithSignature`.
+
+### `abi.encodeCall`
+
+`abi.encodeCall` recebe um ponteiro de função como primeiro parâmetro e os argumentos da função em uma tupla como segundo parâmetro. Diferentemente de escrever manualmente uma assinatura de função ou um seletor, ele verifica a assinatura e os tipos dos argumentos em tempo de compilação; por isso é mais seguro quando a função de destino é conhecida.
+
+```solidity
+function foo(uint256, address, string memory, uint256[2] memory) external pure {}
+
+function encodeCall() public view returns(bytes memory result) {
+    result = abi.encodeCall(this.foo, (x, addr, name, array));
+}
+```
+
+Os dados de chamada codificados são iguais aos de `abi.encodeWithSignature("foo(uint256,address,string,uint256[2])", ...)`, mas não exigem escrever manualmente a assinatura da função.
 
 ## Decodificação ABI
 


### PR DESCRIPTION
## What & Why

Closes #801.

`abi.encodeCall` is the compile-time-checked counterpart of `abi.encodeWithSignature` / `abi.encodeWithSelector`. Issue #801 asks for it to be added to the 27_ABIEncode chapter, and provides the canonical example.

This PR adds the fifth ABI encoding function to the chapter:

- `27_ABIEncode/ABIEncode.sol`: add a `foo(uint256,address,string,uint256[2])` stub and an `encodeCall()` example that mirrors the existing `encodeWithSignature` / `encodeWithSelector` examples (same `x`, `addr`, `name`, `array` state).
- `27_ABIEncode/readme.md`: refresh the intro (4 -> 5 functions) and add a dedicated `### abi.encodeCall` section that explains the compile-time signature/type check and that the calldata matches `abi.encodeWithSignature("foo(uint256,address,string,uint256[2])", ...)`.
- `Languages/pt-br/27_ABIEncode/{ABIEncode.sol,readme.md}`: mirror the same code and readme changes for the Portuguese localization, keeping the chapter in sync across translations.

The chapter structure and example style are unchanged; only the new section is appended between `abi.encodeWithSelector` and `abi.decode`.

### Type of PR

- [ ] Typo(勘误)
- [ ] BUG(程序错误)
- [x] Improvement(提升)
- [ ] Feature(新特性)

### Refs

- Issue: #801
- Existing chapter examples: `encodeWithSignature`, `encodeWithSelector` in `27_ABIEncode/ABIEncode.sol`.