### PR TITLE
fix(Languages/pt-br/10_InsertionSort): restore ifElseTest, remove JS tool residue

### DIFF
--- a/Languages/pt-br/10_InsertionSort/InsertionSort.sol
+++ b/Languages/pt-br/10_InsertionSort/InsertionSort.sol
@@ -2,11 +2,11 @@
 pragma solidity ^0.8.34;
 contract InsertionSort {
     // if else
-    
-        if (text.includes('zh')) {
-            text = translate(text, 'zh', 'pt-br');
-        } else {
-            text = text;
+    function ifElseTest(uint256 _number) public pure returns(bool){
+        if(_number == 0){
+            return(true);
+        }else{
+            return(false);
         }
     }
 


### PR DESCRIPTION
## What & Why

The pt-br localization of `Languages/pt-br/10_InsertionSort/InsertionSort.sol` contains a JavaScript translation-tool fragment where the `ifElseTest` function body should be. The stray lines are not valid Solidity, and the contract does not compile in its current form:

```solidity
contract InsertionSort {
    // if else

        if (text.includes('zh')) {
            text = translate(text, 'zh', 'pt-br');
        } else {
            text = text;
        }
    }
```

This almost certainly came from an automated translation pass that did not skip code blocks.

This PR restores the `ifElseTest(uint256 _number)` function, matching the root `10_InsertionSort/InsertionSort.sol` and the code block already documented in `Languages/pt-br/10_InsertionSort/readme.md`:

```solidity
function ifElseTest(uint256 _number) public pure returns(bool){
    if(_number == 0){
        return(true);
    }else{
        return(false);
    }
}
```

After the fix, the diff (ignoring comments) between the root and pt-br `InsertionSort.sol` is empty, so the localized contract is functionally identical to the canonical one.

### Scope

- Single file: `Languages/pt-br/10_InsertionSort/InsertionSort.sol`
- `+5 / -5` lines (the JS fragment was 5 non-comment lines; the `ifElseTest` body is also 5 lines plus closing braces).

### Type of PR

- [ ] Typo(勘误)
- [x] BUG(程序错误)
- [ ] Improvement(提升)
- [ ] Feature(新特性)

### How to verify

```bash
solc Languages/pt-br/10_InsertionSort/InsertionSort.sol
```

should succeed (it currently fails with `ParserError` on the `text.includes('zh')` line).
