### PR TITLE
fix(Languages): complete contrib.rocks repo rename left over from #742

### DIFF
--- a/Languages/en/README.md
+++ b/Languages/en/README.md
@@ -165,7 +165,7 @@ Tutorials and codes are open-sourced on github: [github.com/AmazingAng/WTF-Solid
     Contributors are the basis of WTF Academy
   </h4>
   <a href="https://github.com/AmazingAng/WTF-Solidity/graphs/contributors">
-    <img src="https://contrib.rocks/image?repo=AmazingAng/WTFSolidity" />
+    <img src="https://contrib.rocks/image?repo=AmazingAng/WTF-Solidity" />
   </a>
 </div>
 

--- a/Languages/es/README.md
+++ b/Languages/es/README.md
@@ -87,7 +87,7 @@ Los códigos y tutoriales están como código abierto en GitHub: [github.com/Ama
     Contributors are the basis of WTF Academy
   </h4>
   <a href="https://github.com/AmazingAng/WTF-Solidity/graphs/contributors">
-    <img src="https://contrib.rocks/image?repo=AmazingAng/WTFSolidity" />
+    <img src="https://contrib.rocks/image?repo=AmazingAng/WTF-Solidity" />
   </a>
 </div>
 

--- a/Languages/pt-br/README.md
+++ b/Languages/pt-br/README.md
@@ -307,7 +307,7 @@ O roteiro será definido com base no número de estrelas deste repositório:
     Os contribuidores são a base da Academia WTF
   </h4>
   <a href="https://github.com/AmazingAng/WTF-Solidity/graphs/contributors">
-    <img src="https://contrib.rocks/image?repo=AmazingAng/WTFSolidity" />
+    <img src="https://contrib.rocks/image?repo=AmazingAng/WTF-Solidity" />
   </a>
 </div>
 


### PR DESCRIPTION
## What & Why

PR #742 (`feat(repo): fix repo name`) renamed the `contrib.rocks` avatar URL on the root `README.md` from `AmazingAng/WTFSolidity` to `AmazingAng/WTF-Solidity` (the actual repository name, with hyphen). The three translated top-level READMEs were missed in that pass, so they still point at `AmazingAng/WTFSolidity`, which `contrib.rocks` cannot resolve to a real repository — the contributor avatar block on those READMEs silently renders empty.

This PR applies the same one-token rename to the three affected READMEs:

- `Languages/pt-br/README.md`
- `Languages/es/README.md`
- `Languages/en/README.md`

Three single-line edits, `+3 / -3`. Each change is exactly:

```diff
-    <img src="https://contrib.rocks/image?repo=AmazingAng/WTFSolidity" />
+    <img src="https://contrib.rocks/image?repo=AmazingAng/WTF-Solidity" />
```

No other lines are touched.

### Type of PR

- [x] Typo(勘误)
- [ ] BUG(程序错误)
- [ ] Improvement(提升)
- [ ] Feature(新特性)

### Refs

- Pattern established by merged PR #742 (`feat(repo): fix repo name`).
