### PR TITLE
fix(Languages/{es,en}/29_Selector): pass address, not string, to abi.encodeWithSelector

### DIFF
--- a/Languages/en/29_Selector_en/Selector.sol
+++ b/Languages/en/29_Selector_en/Selector.sol
@@ -24,7 +24,7 @@ contract Selector {
         (bool success, bytes memory data) = address(this).call(
             abi.encodeWithSelector(
                 0x6a627842,
-                "0x2c44b726ADF1963cA47Af88B284C06f30380fC78"
+                0x2c44b726ADF1963cA47Af88B284C06f30380fC78
             )
         );
         return (success, data);

--- a/Languages/en/29_Selector_en/readme.md
+++ b/Languages/en/29_Selector_en/readme.md
@@ -85,7 +85,7 @@ We can use `selector` to call the target function. For example, if I want to cal
 
 ````solidity
      function callWithSignature() external returns(bool, bytes memory){
-         (bool success, bytes memory data) = address(this).call(abi.encodeWithSelector(0x6a627842, "0x2c44b726ADF1963cA47Af88B284C06f30380fC78"));
+         (bool success, bytes memory data) = address(this).call(abi.encodeWithSelector(0x6a627842, 0x2c44b726ADF1963cA47Af88B284C06f30380fC78));
          return(success, data);
      }
 ````

--- a/Languages/es/29_Selector_es/Selector.sol
+++ b/Languages/es/29_Selector_es/Selector.sol
@@ -24,7 +24,7 @@ contract Selector {
         (bool success, bytes memory data) = address(this).call(
             abi.encodeWithSelector(
                 0x6a627842,
-                "0x2c44b726ADF1963cA47Af88B284C06f30380fC78"
+                0x2c44b726ADF1963cA47Af88B284C06f30380fC78
             )
         );
         return (success, data);

--- a/Languages/es/29_Selector_es/readme.md
+++ b/Languages/es/29_Selector_es/readme.md
@@ -85,7 +85,7 @@ El resultado es `0x6a627842`:
 Se puede usar `selector` para llamar a la función de destino. Por ejemplo, si se quiere llamar a la función `mint`, solo se necesita usar `abi.encodeWithSelector` para empaquetar y codificar el `method id` de la función `mint` como el `selector` y los parámetros, y pasarlo a la función `call`:
 ```solidity
     function callWithSignature() external returns(bool, bytes memory){
-        (bool success, bytes memory data) = address(this).call(abi.encodeWithSelector(0x6a627842, "0x2c44b726ADF1963cA47Af88B284C06f30380fC78"));
+        (bool success, bytes memory data) = address(this).call(abi.encodeWithSelector(0x6a627842, 0x2c44b726ADF1963cA47Af88B284C06f30380fC78));
         return(success, data);
     }
 ```


### PR DESCRIPTION
## What & Why

The Spanish and English localizations of `29_Selector` pass the `mint(address)` argument to `abi.encodeWithSelector` as a **string literal** instead of an **address literal**:

```solidity
abi.encodeWithSelector(0x6a627842, "0x2c44b726ADF1963cA47Af88B284C06f30380fC78")
```

The selector `0x6a627842` is `mint(address)`, so `abi.encodeWithSelector` expects an `address` argument. Passing a `string` produces a completely different calldata encoding (string offset + length + bytes payload) than the 4-byte selector + 32-byte left-padded address the chapter itself documents just above the example:

```
0x6a6278420000000000000000000000002c44b726adf1963ca47af88b284c06f30380fc78
```

The pt-br localization already passes the argument correctly as an `address` literal (no quotes). This PR brings `es` and `en` in line with `pt-br` and with the documented calldata.

### Files

- `Languages/es/29_Selector_es/Selector.sol`
- `Languages/es/29_Selector_es/readme.md`
- `Languages/en/29_Selector_en/Selector.sol`
- `Languages/en/29_Selector_en/readme.md`

Four single-line edits, `+4 / -4`. Each change is exactly:

```diff
-                "0x2c44b726ADF1963cA47Af88B284C06f30380fC78"
+                0x2c44b726ADF1963cA47Af88B284C06f30380fC78
```

### Type of PR

- [ ] Typo(勘误)
- [x] BUG(程序错误)
- [ ] Improvement(提升)
- [ ] Feature(新特性)

### Cross-reference

The pt-br version (`Languages/pt-br/29_Selector/Selector.sol`) was used as the canonical correct pattern.
