### PR TITLE
docs(TOOL07_Foundry): align header block with TOOL08 canonical style

### DIFF
--- a/Topics/Tools/TOOL07_Foundry/readme.md
+++ b/Topics/Tools/TOOL07_Foundry/readme.md
@@ -1,14 +1,14 @@
-# WTF Solidity极简入门-工具篇7: Foundry，以Solidity为中心的开发工具包
+# WTF Solidity 极简入门-工具篇 7：Foundry，以 Solidity 为中心的开发工具包
 
-我最近在重新学solidity，巩固一下细节，也写一个“WTF Solidity极简入门”，供小白们使用），每周更新1-3讲。
+我最近在重新学 Solidity，巩固一下细节，也写一个“WTF Solidity 极简入门”，供小白们使用（编程大佬可以另找教程），每周更新 1-3 讲。
 
-推特：[@0xAA_Science](https://twitter.com/0xAA_Science)
+推特：[@0xAA_Science](https://twitter.com/0xAA_Science)｜[@WTFAcademy\_](https://twitter.com/WTFAcademy_)
 
 社区：[Discord](https://discord.gg/5akcruXrsk)｜[微信群](https://docs.google.com/forms/d/e/1FAIpQLSe4KGT8Sh6sJ7hedQRuIYirOoZK_85miz3dw7vA1-YjodgJ-A/viewform?usp=sf_link)｜[官网 wtf.academy](https://wtf.academy)
 
-所有代码和教程开源在github: [github.com/AmazingAng/WTF-Solidity](https://github.com/AmazingAng/WTF-Solidity)
+所有代码和教程开源在 github: [github.com/AmazingAng/WTF-Solidity](https://github.com/AmazingAng/WTF-Solidity)
 
------
+---
 
 ## 什么是 Foundry?
 来自 Foundry [官网 (getfoundry.sh) ](https://getfoundry.sh) 对该工具的介绍：


### PR DESCRIPTION
## What & Why

`Topics/Tools/TOOL07_Foundry/readme.md` is the only Tools-chapter readme whose top header block still uses the pre-standard format. `TOOL01`–`TOOL06` and `TOOL08` already use the canonical style established by the brand-unification pass.

This PR brings `TOOL07` in line with `TOOL08` (the most recent reference) by applying **only header-block changes** (lines 1–11):

| Section | Before | After |
|---------|--------|-------|
| Title | `WTF Solidity极简入门-工具篇7: Foundry，以Solidity为中心的开发工具包` | `WTF Solidity 极简入门-工具篇 7：Foundry，以 Solidity 为中心的开发工具包` |
| Intro | `重新学solidity…供小白们使用），每周更新1-3讲。` | `重新学 Solidity…供小白们使用（编程大佬可以另找教程），每周更新 1-3 讲。` |
| Twitter | `推特：[@0xAA_Science]` | `推特：[@0xAA_Science]｜[@WTFAcademy_]` |
| Repo | `开源在github:` | `开源在 github:` |
| Rule | `-----` | `---` |

5 lines changed, `+5 / -5`. The body content (Foundry tutorial) is untouched.

### Type of PR

- [x] Typo(勘误)
- [ ] BUG(程序错误)
- [x] Improvement(提升)
- [ ] Feature(新特性)

### Refs

- Canonical header reference: `Topics/Tools/TOOL08_ZAN/readme.md`
