### PR TITLE
docs(ERC721/5_Loot): align readme header with sibling ERC721 topics

### DIFF
--- a/Topics/ERC721/5_Loot/readme.md
+++ b/Topics/ERC721/5_Loot/readme.md
@@ -1,14 +1,14 @@
-# WTF Solidity极简入门 ERC721专题5：Loot
+# WTF Solidity极简入门: ERC721专题：5. Loot
 
-我最近在重新学solidity，巩固一下细节，也写一个“WTF Solidity极简入门”，供小白们使用（编程大佬可以另找教程），每周更新1-3讲。
+我最近在重新学 Solidity，巩固一下细节，也写一个“WTF Solidity 极简入门”，供小白们使用（编程大佬可以另找教程），每周更新 1-3 讲。
 
-推特：[@0xAA_Science](https://twitter.com/0xAA_Science)
+推特：[@0xAA_Science](https://twitter.com/0xAA_Science)｜[@WTFAcademy\_](https://twitter.com/WTFAcademy_)
 
 社区：[Discord](https://discord.gg/5akcruXrsk)｜[微信群](https://docs.google.com/forms/d/e/1FAIpQLSe4KGT8Sh6sJ7hedQRuIYirOoZK_85miz3dw7vA1-YjodgJ-A/viewform?usp=sf_link)｜[官网 wtf.academy](https://wtf.academy)
 
-所有代码和教程开源在github: [github.com/AmazingAng/WTF-Solidity](https://github.com/AmazingAng/WTF-Solidity)
+所有代码和教程开源在 github: [github.com/AmazingAng/WTF-Solidity](https://github.com/AmazingAng/WTF-Solidity)
 
------
+---
 
 ## Loot
 


### PR DESCRIPTION
## What & Why

`Topics/ERC721/5_Loot/readme.md` is the only ERC721 topic readme whose top header block still uses the pre-standard format. Sibling topics (`1_related_libraries`, `2_Related_interface`, `3_Erc721_main_contract`) already use the canonical WTF Solidity header style.

This PR brings `5_Loot` in line with them, applying **only header-block changes** (lines 1–11):

| Section | Before | After |
|---------|--------|-------|
| Title | `WTF Solidity极简入门 ERC721专题5：Loot` | `WTF Solidity极简入门: ERC721专题：5. Loot` (matches sibling topic title format) |
| Intro | `重新学solidity…1-3讲` | `重新学 Solidity…1-3 讲` |
| Twitter | `推特：[@0xAA_Science]` | `推特：[@0xAA_Science]｜[@WTFAcademy_]` |
| Repo | `开源在github:` | `开源在 github:` |
| Rule | `-----` | `---` |

5 lines changed, `+5 / -5`. The body content (Loot tutorial) is untouched.

### Type of PR

- [x] Typo(勘误)
- [ ] BUG(程序错误)
- [x] Improvement(提升)
- [ ] Feature(新特性)

### Refs

- Canonical header reference: `Topics/ERC721/1_related_libraries/readme.md`
