### PR TITLE
fix(Languages/en/27_ABIEncode): translate two leftover Chinese section headers

### DIFF
--- a/Languages/en/27_ABIEncode_en/readme.md
+++ b/Languages/en/27_ABIEncode_en/readme.md
@@ -87,7 +87,7 @@ We input binary encoding of `abi.encode` into `decode`, which will decode the or
 
 ![](https://images.mirror-media.xyz/publication-images/jboRaaq0U57qVYjmsOgbv.png?height=408&width=624)
 
-## 在remix上验证
+## Verify on Remix
 - deploy the contract to check the encoding result of `abi.encode`
 ![](./img/27-1_en.png)
 
@@ -97,7 +97,7 @@ We input binary encoding of `abi.encode` into `decode`, which will decode the or
 - check the decoding result of `abi.decode`
 ![](./img/27-3_en.png)
 
-## ABI的使用场景
+## Use cases of ABI
 1. In contract development, ABI is often paired with a call to implement a low-level call to contract.
 ```solidity  
     bytes4 selector = contract.getValue.selector;


### PR DESCRIPTION
## What & Why

`Languages/en/27_ABIEncode_en/readme.md` is the English localization of chapter 27. The chapter body was translated to English, but **two section headings were left in Chinese**, breaking the language-consistency contract that the rest of `Languages/en/*_en/` already follows:

| Line | Before (Chinese) | After (English) |
|------|------------------|-----------------|
| L90  | `## 在remix上验证`  | `## Verify on Remix` |
| L100 | `## ABI的使用场景` | `## Use cases of ABI` |

The body content under both sections was already in English — only the headings were untranslated drift.

### Why this phrasing

- `Verify on Remix` matches the established English style in sibling chapters (e.g. `### verify on remix`, ``## `remix` Verification``).
- `Use cases of ABI` matches the `## Usage of …` / `… use cases?` pattern used in other `Languages/en/*_en/` chapters (e.g. `26_DeleteContract_en`, `23_Delegatecall_en`).

### Files

- `Languages/en/27_ABIEncode_en/readme.md` — **2 lines changed**, no body changes.

### Type of PR

- [x] Typo(勘误) — i18n drift fix
- [ ] BUG
- [ ] Improvement
- [ ] Feature

### Verification

- Sibling chapters `Languages/en/26_DeleteContract_en/`, `Languages/en/23_Delegatecall_en/` confirmed to use English-only section headings.
- CRLF line endings preserved (file keeps Windows-style EOL).
- Diff stat: `1 file changed, 2 insertions(+), 2 deletions(-)`.
