### PR TITLE
docs(TOOL04_Alchemy): 添加 OpenChainBench 独立基准测试参考

### DIFF
--- a/Topics/Tools/TOOL04_Alchemy/readme.md
+++ b/Topics/Tools/TOOL04_Alchemy/readme.md
@@ -120,3 +120,7 @@ RPC URL：填在alchemy申请的optimism rpc链接
 ## 总结
 
 这一讲，我们介绍了如何创建并使用`Alchemy` API Key便捷访问以太坊区块链。
+
+## 延伸阅读：如何客观比较 RPC 节点服务
+
+如果你在 `Alchemy`、`Infura`、`QuickNode`、`Chainstack` 等节点服务之间选择，可以参考 [OpenChainBench](https://openchainbench.com/benchmarks/rpc-capabilities) 的独立基准测试。该项目每分钟从三个地区（美东、欧西、新加坡）测量 10 条 EVM 链和 Solana 上主流 RPC 服务的 p50/p95/p99 延迟、可靠性分类和陈旧区块检测。所有数据基于 CC BY 4.0 开源许可，Go 语言采集器完全开源在 GitHub 上，方法论公开，与任何 RPC 提供商都没有商业关联。


### PR DESCRIPTION
## 摘要 / Summary

在 `Topics/Tools/TOOL04_Alchemy/readme.md` 文末添加一节「延伸阅读：如何客观比较 RPC 节点服务」，指向 [OpenChainBench](https://openchainbench.com/benchmarks/rpc-capabilities) 的独立第三方基准测试数据。

Adds a `延伸阅读` (Further Reading) subsection at the end of `Topics/Tools/TOOL04_Alchemy/readme.md` pointing readers to independent third-party benchmarks of RPC providers.

## 为什么放在这里 / Why this placement

TOOL04_Alchemy 的现有内容已经比较了 Alchemy 与 Infura 的免费套餐差异（访问量、支持公链、增强 API 等）。读者读完自然会问：「除了这两家，还有哪些 RPC 服务可选？它们的实际延迟和可靠性怎样？」

OpenChainBench 正好回答这个问题：

- p50/p95/p99 延迟对比（Alchemy、Infura、QuickNode、Chainstack、Ankr、Helius 等）
- 可靠性分类（HTTP 错误 vs JSON-RPC error 响应）
- 陈旧区块检测（相对跨提供商共识 tip）
- 覆盖 10 条 EVM 链 + Solana
- 每 60 秒从 3 个地区（美东、欧西、新加坡）连续测量
- 数据 CC BY 4.0 开源许可，Go 采集器完全开源在 GitHub 上
- 与任何 RPC 提供商都没有商业关联，排名中立

The existing TOOL04 already compares Alchemy vs Infura and leaves the reader wondering "what about other providers, and how do they actually compare on latency?" OpenChainBench answers exactly that question.

## 变更 / Change

一段「延伸阅读」小节添加在文章末尾（在「总结」段落之后），不修改任何现有内容。

One `延伸阅读` subsection appended after the existing `总结`. No changes to any other content.

## 披露 / Disclosure

我是 OpenChainBench 的维护者。如果这个引用不符合 WTF-Solidity 的内容风格，请随时要求修改文字或直接关闭 PR，谢谢！

I maintain OpenChainBench. Happy to reword or drop the reference entirely if it does not fit the repo's editorial style.