### PR TITLE
fix(Languages/ja/12_Event): repair broken image reference

### DIFF
--- a/Languages/ja/12_Event_ja/readme.md
+++ b/Languages/ja/12_Event_ja/readme.md
@@ -59,7 +59,7 @@ event Transfer(address indexed from, address indexed to, uint256 value);
 
 EVMはSolidityのイベントを保管する為に`Log`を使用します。各ログは2つの部品を含んでいます: `topics`と`data`です。
 
-![](img/12-3.png)
+![](./img/12-3_ja.png)
 
 ### `Topics`
 


### PR DESCRIPTION
Line 62 of `Languages/ja/12_Event_ja/readme.md` renders as a broken image:

```
![](img/12-3.png)
```

The Japanese localization only ships `12-1_ja.png`, `12-2_ja.png` and `12-3_ja.png` under `Languages/ja/12_Event_ja/img/` — the file `12-3.png` does not exist there. This figure illustrates the `Log` topics/data structure, which is essential to the lesson.

The same figure is already referenced correctly on line 101 of this same file as `./img/12-3_ja.png`. This PR aligns line 62 with that existing form.

**Scope:** 1 file, 1 line — purely a path correction.

Verification on `origin/main` (`d3fec719`):
- `ls Languages/ja/12_Event_ja/img/` → `12-1_ja.png  12-2_ja.png  12-3_ja.png` (no `12-3.png`)
- The corresponding figure exists in canonical `12_Event/img/12-3.png` and `Languages/en/12_Event_en/img/12-3.jpg`, confirming this illustration is required.

Continuation of the docs hygiene sweep started in #922.
