### PR TITLE
fix(Languages/es/22_Metodo_llamar): correct previous chapter link

### DIFF
--- a/Languages/es/22_Metodo_llamar_es/readme.md
+++ b/Languages/es/22_Metodo_llamar_es/readme.md
@@ -30,7 +30,7 @@ Anteriormente en [20: Enviar ETH](https://github.com/AmazingAng/WTF-Solidity/tre
 `call` es una de las funciones de bajo nivel de `address` que se utiliza para interactuar con otros contratos. Devuelve la condición de éxito y los datos devueltos: `(bool, data)`.
 
 - Oficialmente recomendado por `solidity`, `call` se utiliza para enviar `ETH` al activar funciones `fallback` o `receive`.
-- `call` no es recomendado para interactuar con otros contratos, porque cede el control al llamar a un contrato malicioso. La forma recomendada es crear una referencia de contrato y llamar a sus funciones. Ver [21: Interactuar con otro Contrato](https://github.com/AmazingAng/WTF-Solidity/tree/main/Languages/en/21_LamarContrato_es)
+- `call` no es recomendado para interactuar con otros contratos, porque cede el control al llamar a un contrato malicioso. La forma recomendada es crear una referencia de contrato y llamar a sus funciones. Ver [21: Interactuar con otro Contrato](https://github.com/AmazingAng/WTF-Solidity/tree/main/Languages/es/21_LlamarContrato_es)
 - Si el código fuente o `ABI` no está disponible, no podemos crear una variable de contrato; sin embargo, aún podemos interactuar con otros contratos utilizando la función `call`.
 
 ### Reglas de uso de `call`


### PR DESCRIPTION
Line 33 of `Languages/es/22_Metodo_llamar_es/readme.md` links to the previous chapter via:

```
[21: Interactuar con otro Contrato](https://github.com/AmazingAng/WTF-Solidity/tree/main/Languages/en/21_LamarContrato_es)
```

That URL points to a path that does not exist:

- `Languages/en/21_LamarContrato_es/` — the English tree does not host Spanish localizations, and the directory name mixes the English prefix `en/` with a Spanish suffix `_es`.
- The misspelled `Lamar` (instead of the correct Spanish `Llamar`) does not match any real directory under `Languages/`.

The intended target is the Spanish chapter 21, which lives at `Languages/es/21_LlamarContrato_es/readme.md`. This PR aligns the prev-chapter link with that path, matching the pattern of the chapter-20 back-reference on line 30 of the same file.

**Scope:** 1 file, 1 line — purely a path correction.

Continuation of the docs hygiene sweep started in #922.
