### PR TITLE
fix(Languages/es/22_Metodo_llamar): correct Spanish spelling in code comments

### DIFF
--- a/Languages/es/22_Metodo_llamar_es/readme.md
+++ b/Languages/es/22_Metodo_llamar_es/readme.md
@@ -105,12 +105,12 @@ Ahora se declara la función `callSetX` para llamar a la función objetivo `setX
 
 ```solidity
 function callSetX(address payable _addr, uint256 x) public payable {
-    // Lamar a setX(), y enviar ETH
+    // Llamar a setX(), y enviar ETH
 	(bool success, bytes memory data) = _addr.call{value: msg.value}(
 		abi.encodeWithSignature("setX(uint256)", x)
 	);
 
-	emit Response(success, data); //emiter evento
+	emit Response(success, data); //emitir evento
 }
 ```
 
@@ -125,12 +125,12 @@ A continuación, se llama a la función `getX()`, y devolverá el valor de `_x` 
 
 ```solidity
 function callGetX(address _addr) external returns(uint256){
-    // Lammar getX()
+    // Llamar getX()
 	(bool success, bytes memory data) = _addr.call(
 		abi.encodeWithSignature("getX()")
 	);
 
-	emit Response(success, data); //emiter evento
+	emit Response(success, data); //emitir evento
 	return abi.decode(data, (uint256));
 }
 ```
@@ -150,7 +150,7 @@ function callNonExist(address _addr) external{
 		abi.encodeWithSignature("foo(uint256)")
 	);
 
-	emit Response(success, data); //emiter Evento
+	emit Response(success, data); //emitir evento
 }
 ```
 


### PR DESCRIPTION
Several inline code comments in `Languages/es/22_Metodo_llamar_es/readme.md` contained Spanish spelling mistakes that disagree with the rest of the file and with the sibling `Call.sol`:

| Line | Before | After |
| --- | --- | --- |
| 108 | `// Lamar a setX(), y enviar ETH` | `// Llamar a setX(), y enviar ETH` |
| 113 | `//emiter evento` | `//emitir evento` |
| 128 | `// Lammar getX()` | `// Llamar getX()` |
| 133 | `//emiter evento` | `//emitir evento` |
| 153 | `//emiter Evento` | `//emitir evento` |

The matching `Call.sol` comments in the same chapter were already corrected to `Llamar` / `emitir` in commit `c25c0e02` (`Apply suggestions from code review`). The rest of this readme also consistently uses `Llamar` (correct Spanish imperative / infinitive for "to call") and `emitir`. This PR aligns the readme's inline comments with those established forms.

**Scope:** 1 file, 5 inline-comment edits.

Continuation of the docs hygiene sweep started in #922.
