### PR TITLE
docs(README): point Loot lecture article link at in-repo readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@
 
 **第4讲：BAYC主合约和严重漏洞** [代码](https://github.com/AmazingAng/WTF-Solidity/blob/main/Topics/ERC721/BAYC.sol) | [文章](https://mirror.xyz/wtfacademy.eth/_buBOQflWtHDpLbg18Fp8zLe8AmLiPka2y-UhppK_u0)
 
-**第5讲：Loot** [代码](https://github.com/AmazingAng/WTF-Solidity/blob/main/Topics/ERC721/5_Loot/Loot.sol) | [文章](https://mirror.xyz/wtfacademy.eth/-Bc_vjP9EX-wg6chtUFAz0zm5v-jaIekMlOlqHJ_IhE)
+**第5讲：Loot** [代码](https://github.com/AmazingAng/WTF-Solidity/blob/main/Topics/ERC721/5_Loot/Loot.sol) | [文章](https://github.com/AmazingAng/WTF-Solidity/tree/main/Topics/ERC721/5_Loot/readme.md)
 
 ### 翻译
 


### PR DESCRIPTION
Line 301 of `README.md` currently links the Loot lecture's `[文章]` entry to an external `mirror.xyz` post:

```
**第5讲：Loot** [代码](.../5_Loot/Loot.sol) | [文章](https://mirror.xyz/wtfacademy.eth/-Bc_vjP9EX-wg6chtUFAz0zm5v-jaIekMlOlqHJ_IhE)
```

The sibling ERC721 lectures 1–3 (README.md lines 293, 295, 297) all link to the corresponding in-repo `Topics/ERC721/.../readme.md`, and the Loot lecture itself ships such a readme at `Topics/ERC721/5_Loot/readme.md`. Pointing the article link at the in-repo readme aligns line 301 with the same internal pattern and removes the dependency on a third-party mirror that has been winding down.

**Scope:** 1 file, 1 line — only the Loot article link is changed. The BAYC lecture on line 299 also uses an external `mirror.xyz` link, but BAYC has no in-repo lecture readme, so it is intentionally left untouched.

Continuation of the docs hygiene sweep started in #922.
