### PR TITLE
fix(03_Function): correct function visibility teaching across langs

### DIFF
--- a/03_Function/Function.sol
+++ b/03_Function/Function.sol
@@ -6,7 +6,7 @@ contract FunctionTypes{
     constructor() payable {}
 
     // 函数类型
-    // function (<parameter types>) {internal|external} [pure|view|payable] [returns (<return types>)]
+    // function (<parameter types>) {internal|external|public|private} [pure|view|payable] [returns (<return types>)]
     // 默认function
     function add() external{
         number = number + 1;

--- a/Languages/en/03_Function_en/Function.sol
+++ b/Languages/en/03_Function_en/Function.sol
@@ -6,7 +6,7 @@ contract FunctionTypes{
     constructor() payable {}
 
     // function type
-    // function (<parameter types>) {internal|external} [pure|view|payable] [returns (<return types>)]
+    // function (<parameter types>) {internal|external|public|private} [pure|view|payable] [returns (<return types>)]
     // default function
     function add() external{
         number = number + 1;

--- a/Languages/en/03_Function_en/readme.md
+++ b/Languages/en/03_Function_en/readme.md
@@ -16,7 +16,7 @@ Codes and tutorials are open source on GitHub: [github.com/AmazingAng/WTF-Solidi
 Here's the format of a function in Solidity:
 
 ```solidity
-    function <function name>(<parameter types>) [internal|external] [pure|view|payable] [returns (<return types>)]
+    function <function name>(<parameter types>) {internal|external|public|private} [pure|view|payable] [returns (<return types>)]
 ```
 
 It may seem complex, but let's break it down piece by piece (square brackets indicate optional keywords):
@@ -38,7 +38,7 @@ It may seem complex, but let's break it down piece by piece (square brackets ind
 
    - `internal`: Can only be accessed internally and by contracts deriving from it.
 
-    **Note 1**: `public` is the default visibility for functions.
+    **Note 1**: Functions have no default visibility — you must specify one of `public`, `private`, `internal`, or `external` explicitly.
     
     **Note 2**: `public|private|internal` can be also used on state variables. Public variables will automatically generate `getter` functions for querying values. 
     

--- a/Languages/ja/03_Function_ja/Function.sol
+++ b/Languages/ja/03_Function_ja/Function.sol
@@ -6,7 +6,7 @@ contract FunctionTypes{
     constructor() payable {}
 
     // function type（関数型）
-    // function (<parameter types>) {internal|external} [pure|view|payable] [returns (<return types>)]
+    // function (<parameter types>) {internal|external|public|private} [pure|view|payable] [returns (<return types>)]
     // default function（デフォルトの関数）
     function add() external{
         number = number + 1;

--- a/Languages/ja/03_Function_ja/readme.md
+++ b/Languages/ja/03_Function_ja/readme.md
@@ -15,7 +15,7 @@
 Solidityにおける関数の書式を示します:
 
 ```solidity
-    function <function name>(<parameter types>) [internal|external] [pure|view|payable] [returns (<return types>)]
+    function <function name>(<parameter types>) {internal|external|public|private} [pure|view|payable] [returns (<return types>)]
 ```
 
 複雑に見えるかもしれませんが、１つ１つ分解して見てみましょう（角括弧はオプションのキーワードを示します）:
@@ -37,7 +37,7 @@ Solidityにおける関数の書式を示します:
 
    - `internal`: コントラクト内部およびそのコントラクトから派生するコントラクトからのみアクセス出来る。
 
-    **Note 1**: `public`はデフォルトで関数のビジビリティとなっています。
+    **Note 1**: 関数にはデフォルトのビジビリティはありません。`public`、`private`、`internal`、`external` のいずれかを明示的に指定する必要があります。
     
     **Note 2**: `public|private|internal`は状態変数でも使用されます。パブリックな変数は値を照会する為の`getter`関数を自動的に生成します。
     


### PR DESCRIPTION
The Lecture 03 (Function) tutorial teaches an incorrect rule in the English and Japanese translations:

> **Note 1**: `public` is the default visibility for functions.

This contradicts both (a) the canonical Chinese readme, which says functions need explicit visibility with no default, and (b) the same English/Japanese readme's own bullet list, which already states correctly:

> `[{internal|external|public|private}]`: Function visibility specifiers. There is no default visibility, so you must specify it for each function.

Since Solidity 0.5.0, functions cannot rely on a default `public` visibility — explicit visibility is required. So the "public is default" note is misleading and can produce real bugs in readers' contracts.

This PR aligns the translations with the canonical Chinese readme:

| File | Change |
| --- | --- |
| `Languages/en/03_Function_en/readme.md` | signature: `[internal\|external]` → `{internal\|external\|public\|private}`; **Note 1** rewritten to state there is no default visibility |
| `Languages/ja/03_Function_ja/readme.md` | same two changes (Japanese) |
| `03_Function/Function.sol` | inline comment: `{internal\|external}` → `{internal\|external\|public\|private}` |
| `Languages/en/03_Function_en/Function.sol` | same inline comment fix |
| `Languages/ja/03_Function_ja/Function.sol` | same inline comment fix |

The canonical Chinese readme at `03_Function/readme.md` is already correct and is left unchanged.

References:
- Solidity 0.5.0 breaking change: functions must specify visibility explicitly
- Canonical `03_Function/readme.md` line 41: `{internal|external|public|private}`
- Canonical `03_Function/readme.md` **Note 1**: "合约中定义的函数需要明确指定可见性，它们没有默认值"

**Scope:** 5 files, 7 line edits — purely teaching-text correctness, no code behavior change.

Continuation of the docs hygiene sweep started in #922.
