### PR TITLE
fix(es): remove stray plaintext from chapter 26 sample

### DIFF
--- a/Languages/es/26_EliminarContrato_es/DeleteContract.sol
+++ b/Languages/es/26_EliminarContrato_es/DeleteContract.sol
@@ -19,7 +19,3 @@ contract DeleteContract {
         balance = address(this).balance;
     }
 }
-
-
-Revisar el balance del contrato después del despliegue
-Check the balance of contract after deployed


### PR DESCRIPTION
## What this PR does

- Remove the two bare natural-language lines after the closing brace in `Languages/es/26_EliminarContrato_es/DeleteContract.sol`.

## Why we need it

Those lines are instructions duplicated by the chapter README, but they are not Solidity comments. A learner copying the Spanish chapter sample into a Solidity compiler encounters a parser error after the contract body. The English, Portuguese, and Japanese chapter 26 samples end at the closing brace.

This is intentionally limited to one Spanish leaf source file; the README instructions and contract behavior are unchanged.

## Validation

- `git diff --check`
- Source-level brace and tail assertions

`solc` and `forge` are not installed in the submission environment, so no compiler result is claimed.
