### PR TITLE
fix(31): reject ERC20 transfers to zero address

### DIFF
--- a/31_ERC20/ERC20.sol
+++ b/31_ERC20/ERC20.sol
@@ -26,6 +26,7 @@ contract ERC20 is IERC20 {
 
     // @dev 实现`transfer`函数，代币转账逻辑
     function transfer(address recipient, uint amount) public override returns (bool) {
+        require(recipient != address(0), "transfer to zero address");
         balanceOf[msg.sender] -= amount;
         balanceOf[recipient] += amount;
         emit Transfer(msg.sender, recipient, amount);
@@ -45,6 +46,7 @@ contract ERC20 is IERC20 {
         address recipient,
         uint amount
     ) public override returns (bool) {
+        require(recipient != address(0), "transfer to zero address");
         allowance[sender][msg.sender] -= amount;
         balanceOf[sender] -= amount;
         balanceOf[recipient] += amount;

--- a/31_ERC20/readme.md
+++ b/31_ERC20/readme.md
@@ -172,6 +172,7 @@ uint8 public decimals = 18; // 小数位数
 
     ```solidity
     function transfer(address recipient, uint amount) public override returns (bool) {
+        require(recipient != address(0), "transfer to zero address");
         balanceOf[msg.sender] -= amount;
         balanceOf[recipient] += amount;
         emit Transfer(msg.sender, recipient, amount);
@@ -197,6 +198,7 @@ uint8 public decimals = 18; // 小数位数
         address recipient,
         uint amount
     ) public override returns (bool) {
+        require(recipient != address(0), "transfer to zero address");
         allowance[sender][msg.sender] -= amount;
         balanceOf[sender] -= amount;
         balanceOf[recipient] += amount;


### PR DESCRIPTION
## What this PR does

- Reject transfers to `address(0)` in `31_ERC20/ERC20.sol` for both `transfer` and `transferFrom`.
- Keep the chapter README's executable code sample in sync with the contract.

## Why this matters

The tutorial's normal transfer paths currently credit the zero address without a guard, which can silently destroy tokens instead of performing a valid transfer. The zero address remains intentionally used by the chapter's `mint` and `burn` examples for supply events.

## Validation

- `git diff --check`
- Source assertions verified both guards and preserved mint/burn zero-address event semantics.
- `forge` and `solc` are unavailable in the submission environment, so no compiler result is claimed.
