### PR TITLE
docs(pt-br): add honeypot prevention method

### DIFF
--- a/Languages/pt-br/S10_Honeypot/readme.md
+++ b/Languages/pt-br/S10_Honeypot/readme.md
@@ -114,7 +114,8 @@ Os tokens Pixiu são uma das fraudes mais comuns que os investidores enfrentam n
 
 5. Invista apenas em projetos que você conheça bem, faça sua própria pesquisa (DYOR).
 
+6. Use o Tenderly ou o Phalcon para simular a venda do token Pixiu em um fork; se a simulação falhar, considere isso um forte indício de que o token pode ser um Pixiu.
+
 ## Conclusão
 
 Nesta lição, abordamos contratos Pixiu e métodos para evitar cair em armadilhas Pixiu. Os contratos Pixiu são uma das adversidades mais comuns que investidores enfrentam no mundo cripto, sendo bastante odiados. Recentemente, também surgiram Pixiu NFTs, onde projetos maliciosos alteram as funções de transferência ou autorização do ERC721 para impedir que os investidores vendam. Compreender os princípios dos contratos Pixiu e as medidas de prevenção pode reduzir significativamente a probabilidade de adquirir um contrato Pixiu, tornando seus fundos mais seguros. Mantenha-se sempre aprendendo.
-


### PR DESCRIPTION
## Summary

- Restore the sixth prevention method in the PT-BR S10 Honeypot tutorial.
- Align `Languages/pt-br/S10_Honeypot/readme.md` with the six-item Chinese source lesson.
- Phrase the fork simulation result as a strong indication that warrants further investigation, rather than an absolute diagnosis.

## Why

The Chinese source includes a Tenderly/Phalcon fork-simulation check in its prevention section, while the PT-BR prevention list stopped at five items. The separate sixth Remix reproduction step does not provide the missing prevention guidance.

This is a documentation-only, one-file change. No Solidity code, dependencies, or tests are changed.

## Validation

- `git diff --check`
- Exact section assertions confirm six numbered prevention methods and the new Tenderly/Phalcon guidance.
