### PR TITLE
docs(es): normalize frontmatter title keys

### DIFF
--- a/Languages/es/21_LlamarContrato_es/readme.md
+++ b/Languages/es/21_LlamarContrato_es/readme.md
@@ -1,5 +1,5 @@
 ---
-title: 21. Interactuar con un Contrato externo
+Título: 21. Interactuar con un Contrato externo
 tags:
   - solidity
   - avanzado

--- a/Languages/es/26_EliminarContrato_es/readme.md
+++ b/Languages/es/26_EliminarContrato_es/readme.md
@@ -1,5 +1,5 @@
 ---
-Title: 26. Eliminar contrato
+Título: 26. Eliminar contrato
 tags:
   - solidity
   - advanced


### PR DESCRIPTION
## Summary

- Normalize the Spanish frontmatter key in chapter 21 from `title` to `Título`.
- Normalize the Spanish frontmatter key in chapter 26 from `Title` to `Título`.

This keeps the existing title values, tags, and document content unchanged. It completes the two remaining key-name inconsistencies observed after the historical title cleanup in [#666](https://github.com/AmazingAng/WTF-Solidity/pull/666).

## Verification

- `git diff --check`
- YAML frontmatter parsed successfully for both files.
- Exact two-file, two-line diff verified.

Related historical context: [#664](https://github.com/AmazingAng/WTF-Solidity/issues/664).
