### PR TITLE
docs(es): fix inline code and brand typos

### DIFF
--- a/Languages/es/09_Constante_es/readme.md
+++ b/Languages/es/09_Constante_es/readme.md
@@ -45,7 +45,7 @@ Las variables de tipo `immutable` pueden inicializarse durante la declaración o
     uint256 public immutable IMMUTABLE_TEST;
 ```
 
-Se pueden inicializar las variables de tipo `immutable` usando una variable global como `address(this)`, `block`.`number`, o una función personalizada. En el siguiente ejemplo, se usa la función `test()` para inicializar la variable `IMMUTABLE_TEST` con un valor de `9`:
+Se pueden inicializar las variables de tipo `immutable` usando una variable global como `address(this)`, `block.number`, o una función personalizada. En el siguiente ejemplo, se usa la función `test()` para inicializar la variable `IMMUTABLE_TEST` con un valor de `9`:
 
 ``` solidity
      // Las variables inmutables se inicializan en el constructor, para que puedan ser usadas

--- a/Languages/es/11_Modificador_es/readme.md
+++ b/Languages/es/11_Modificador_es/readme.md
@@ -55,7 +55,7 @@ contract Parents {
 
 ![Iron Man's modifier](https://images.mirror-media.xyz/publication-images/nVwXsOVmrYu8rqvKKPMpg.jpg?height=630&width=1200)
 
-Se define un modificador llamado `onlyOwner`. Las Función que usen `OnlyOwner` solo pueden ser llamadas por el propietario (`owner`):
+Se define un modificador llamado `onlyOwner`. Las Función que usen `onlyOwner` solo pueden ser llamadas por el propietario (`owner`):
 ```solidity
    // define el modificador
    modifier onlyOwner {

--- a/Languages/es/11_Modificador_es/readme.md
+++ b/Languages/es/11_Modificador_es/readme.md
@@ -73,7 +73,7 @@ A continuación, definamos una función `changeOwner`, que puede cambiar el prop
 ```
 
 ### Implementación de Ownable de OpenZeppelin:
-`OppenZeppelin` es una organización que mantiene una base de código estandarizada para `Solidity`, Su implementación estándar de `Ownable` está en [este enlace](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/access/Ownable.sol).
+`OpenZeppelin` es una organización que mantiene una base de código estandarizada para `Solidity`, Su implementación estándar de `Ownable` está en [este enlace](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/access/Ownable.sol).
 
 ## Demo en Remix
 Aquí, tomamos Owner.sol como ejemplo.


### PR DESCRIPTION
## Summary

- Fix the Spanish chapter 9 inline-code rendering of `block.number`.
- Correct the `OpenZeppelin` brand spelling in Spanish chapter 11.

The changes are limited to two README lines and keep the surrounding Spanish text, links, and Solidity examples unchanged.

## Verification

- `git diff --check`
- Exact content assertions for `block.number` and `OpenZeppelin`.
- Exact two-file, two-line diff verified.

The corresponding English canonical chapters already contain the corrected forms.
