### PR TITLE
fix(Languages/ja/19_Fallback): correct trigger semantics

### DIFF
--- a/Languages/ja/19_Fallback_ja/readme.md
+++ b/Languages/ja/19_Fallback_ja/readme.md
@@ -64,8 +64,6 @@ receive() external payable {
 fallback() external payable { ... }
 ```
 
-````solidity
-
 私たちは`fallback()`関数を定義し、それがトリガーされると`fallbackCalled`イベントを発生させ、`msg.sender`、`msg.value`、`msg.data`を出力します：
 
 ```solidity
@@ -75,7 +73,7 @@ event fallbackCalled(address Sender, uint Value, bytes Data);
 fallback() external payable{
     emit fallbackCalled(msg.sender, msg.value, msg.data);
 }
-````
+```
 
 ## receive と fallback の違い
 
@@ -97,7 +95,7 @@ receive()あるか?   fallback()
 receive()   fallback()
 ```
 
-簡単にいうと、コントラクトが`ETH`を受け取るとき、`msg.data`が空で`receive()`が存在する場合は`receive()`がトリガーされます。`msg.data`が空で`receive()`が存在しない場合は、`fallback()`がトリガーされます。この場合、`fallback()`は`payable`である必要があります。
+簡単にいうと、コントラクトが`ETH`を受け取るとき、`msg.data`が空で`receive()`が存在する場合は`receive()`がトリガーされます。`msg.data`が空でない、または`receive()`が存在しない場合は、`fallback()`がトリガーされます。この場合、`fallback()`は`payable`である必要があります。
 
 `receive()`と`payable fallback()`が存在しない場合、コントラクトに直接`ETH`を送信するとエラーが発生します（`payable`関数を使ってコントラクトに`ETH`を送信することはできます）。
 


### PR DESCRIPTION
## Summary

- Correct the Japanese lesson 19 explanation of when `fallback()` is triggered.
- Remove the stray outer four-backtick fence so the event example renders as a normal Solidity code block.

## Why

The Japanese text currently says `fallback()` runs when `msg.data` is empty and `receive()` is absent. The canonical and English lessons state that `fallback()` runs when `msg.data` is non-empty or `receive()` is absent. The adjacent four-backtick wrapper also mispairs with the inner Solidity fence.

## Scope

- One file: `Languages/ja/19_Fallback_ja/readme.md`
- No Solidity runtime or other locale changes.

## Validation

- `git diff --check`
- `codespell Languages/ja/19_Fallback_ja/readme.md`
- Balanced Markdown fences and exact semantic assertions against the corrected text.
- Compared the Japanese lesson with `19_Fallback/readme.md` and `Languages/en/19_Fallback_en/readme.md`.

Refs: merged PRs [#583](https://github.com/AmazingAng/WTF-Solidity/pull/583) and [#924](https://github.com/AmazingAng/WTF-Solidity/pull/924) establish the repository's accepted narrow tutorial/docs maintenance shape.
