### PR TITLE
fix(pt-br/36_MerkleTree): restore whitelist mint logic

### DIFF
--- a/Languages/pt-br/36_MerkleTree/MerkleTree.sol
+++ b/Languages/pt-br/36_MerkleTree/MerkleTree.sol
@@ -64,8 +64,8 @@ library MerkleProof {
 }
 
 contract MerkleTree is ERC721 {
-    // Raiz da árvore de Merkle
-    // Registre os endereços já mintados
+    bytes32 immutable public root; // Raiz da árvore de Merkle
+    mapping(address => bool) public mintedAddress; // Registre os endereços já mintados
 
     // Construtor, inicializa o nome, código e raiz da árvore Merkle da coleção NFT.
     constructor(string memory name, string memory symbol, bytes32 merkleroot)
@@ -79,10 +79,14 @@ contract MerkleTree is ERC721 {
     external
     {
         // Merkle verificação aprovada
+        require(_verify(_leaf(account), proof), "Invalid merkle proof");
         // O endereço não foi mintado antes.
+        require(!mintedAddress[account], "Already minted!");
         
         // Registre os endereços que foram mintados
+        mintedAddress[account] = true;
         // mint
+        _mint(account, tokenId);
     }
 
     // Calcular o valor de hash das folhas da árvore de Merkle


### PR DESCRIPTION
## Summary
- Restore the missing `root` and `mintedAddress` state in the PT-BR MerkleTree example.
- Restore Merkle proof validation, duplicate-mint protection, address recording, and `_mint` in `mint()`.

## Why

The PT-BR contract currently leaves `mint()` as comments and does not declare the state used by the documented whitelist flow. The matching English contract and the PT-BR README describe a working Merkle whitelist example; this patch restores that behavior in the localized source without changing its public interface.

## Validation
- `git diff --check` passed.
- Source assertions confirm the root, minted-address mapping, proof guard, duplicate-mint guard, state write, and `_mint` call.
- `codespell` was run; it reported only existing Portuguese false positives in comments.
- `npx solc@0.8.34` was attempted. Compilation is currently blocked by the pre-existing shared `Languages/pt-br/34_ERC721/ERC721.sol` error at `to.isContract()` (missing `using Address for address`), outside this patch.
